### PR TITLE
[Bug-fix] iterate while-loop on response error

### DIFF
--- a/src/cautiousrobot/__main__.py
+++ b/src/cautiousrobot/__main__.py
@@ -172,7 +172,7 @@ def download_images(data, img_dir, log_filepath, error_log_filepath, filename = 
                                             response_code = response.status_code)
                     update_log(log = log_errors, index = i, filepath = error_log_filepath)
 
-        del response
+                del response
 
     return
 

--- a/src/cautiousrobot/__main__.py
+++ b/src/cautiousrobot/__main__.py
@@ -110,13 +110,13 @@ def download_images(data, img_dir, log_filepath, error_log_filepath, filename = 
                     redo = True
                     max_redos -= 1
                     if max_redos <= 0:
-
                         log_errors = log_response(log_errors,
                                         index = i,
                                         image = image_name,
                                         url = url,
                                         response_code = str(e))
                         update_log(log = log_errors, index = i, filepath = error_log_filepath)
+                    continue
                         
                 if response.status_code == 200:
                     redo = False

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,23 @@
+
+import unittest
+from unittest.mock import patch
+import pandas as pd
+from cautiousrobot.__main__ import download_images
+
+# Define constants for download call
+DUMMY_DATA = pd.DataFrame(data = {"filename": ["test_file"],
+                                  "file_url": ["test_url"]})
+IMG_DIR = "test_dir"
+LOG_FILEPATH = "test_log_path"
+ERROR_LOG_FILEPATH = "test_error_log_path"
+
+
+class TestDownload(unittest.TestCase):
+    @patch('requests.get')
+    def test_response_exception(self, get_mock):
+        get_mock.side_effect = Exception
+        download_images(DUMMY_DATA, img_dir = IMG_DIR, log_filepath = LOG_FILEPATH,
+                        error_log_filepath = ERROR_LOG_FILEPATH)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The while-loop must iterate if there's an error in response from server. Otherwise it will throw an `UnboundLocalError: cannot access local variable 'response' where it is not associated with a value` trying to check the response.