### PR TITLE
BuddyCheck Structure re-write

### DIFF
--- a/src/cautiousrobot/utils.py
+++ b/src/cautiousrobot/utils.py
@@ -1,7 +1,6 @@
 # Helper functions for download
 
 import json
-import sys
 import pandas as pd
 
 
@@ -25,7 +24,7 @@ def update_log(log, index, filepath):
 
 def process_csv(csv_path, expected_cols):
     '''
-    Reads a CSV, sets all columns to lowercase (for case-insensitivity, and checks for expected columns.
+    Reads a CSV, sets all columns to lowercase (for case-insensitivity), and checks for expected columns.
     
     Parameters:
     csv_path - String. Path to the CSV.


### PR DESCRIPTION
After discussion with @thompsonmj and @johnbradley, restructured BuddyCheck to work only as Python interface (takes DataFrames as input) in an effort to improve clarity and flexibility: it can be called to do the merge and produce a missing images DataFrame, or a pre-merged dataset can be passed along with the original to get the missing image DataFrame.