### PR TITLE
Update testing workflow with dev dependencies and full python coverage

### DIFF
--- a/.github/workflows/run-pr-tests.yml
+++ b/.github/workflows/run-pr-tests.yml
@@ -1,0 +1,30 @@
+name: run-PR-tests
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: install dependencies
+        run: pip install .[dev]
+        shell: bash
+        
+      - name: run tests
+        run: pytest
+        shell: bash

--- a/.github/workflows/run-push-tests.yml
+++ b/.github/workflows/run-push-tests.yml
@@ -1,7 +1,6 @@
-name: run-tests
+name: run-push-tests
 
 on:
-  pull_request:
   push:
 
 jobs:
@@ -9,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,14 +7,18 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: install dependencies
         run: pip install .[dev]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,11 +17,7 @@ jobs:
           python-version: '3.11'
 
       - name: install dependencies
-        run: pip install .
-        shell: bash
-
-      - name: install pytest
-        run: pip install pytest
+        run: pip install .[dev]
         shell: bash
         
       - name: run tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,10 @@ jobs:
         run: pip install .
         shell: bash
 
-      - name: run test
-        run: python -m unittest
+      - name: install pytest
+        run: pip install pytest
+        shell: bash
+        
+      - name: run tests
+        run: pytest
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "pillow",
     "sum-buddy @ git+https://github.com/Imageomics/sum-buddy.git@v0.1.0-alpha",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
 keywords = [
     "downloader",
     "csv",


### PR DESCRIPTION
Add new tests from PR #20 to testing workflow with `pytest`.

Further updated the tests to run on all supported python versions (3.7+), and switched to a `dev` dependency install (update within the `pyproject.toml`).