### PR TITLE
re-align call to sum-buddy with its updated parameter

### DIFF
--- a/src/cautiousrobot/__main__.py
+++ b/src/cautiousrobot/__main__.py
@@ -268,7 +268,7 @@ def main():
     # then verify the download if checksums in source CSV
     checksum_path = metadata_path + "_checksums.csv"
     try:
-        get_checksums(input_directory = img_dir, output_filepath = checksum_path, algorithm = args.checksum_algorithm)
+        get_checksums(input_path = img_dir, output_filepath = checksum_path, algorithm = args.checksum_algorithm)
         
         # verify numbers
         checksum_df = pd.read_csv(checksum_path, low_memory = False)


### PR DESCRIPTION
In [this sum-buddy update](https://github.com/Imageomics/sum-buddy/commit/2a29e34ecf98d25c6ca4d5665e2b0929fe9cfb48#diff-acfdc9ac3b558d95accc8386bb6ffe8de8abff7de2e938ab3abb59a3d545cd20) the `input_directory` parameter for `get_checksums` was changed to `input_path`, so cautious-robot couldn't get checksums of the downloaded images. This PR changes that parameter in the function call.