### PR TITLE
Update Python Dependencies

### DIFF
--- a/.github/workflows/run-pr-tests.yml
+++ b/.github/workflows/run-pr-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-push-tests.yml
+++ b/.github/workflows/run-push-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I am a simple downloader that downloads images from URLs in a CSV and names them
 
 
 ## Requirements
-Python 3.7+
+Python 3.10+
 
 ## Installation
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "Simple downloader that downloads images from URLs in a CSV and names them by the given column. Then uses sum-buddy to gather and record checksums for all downloaded images."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "argparse",
     "pandas",
     "pillow",
-    "sum-buddy @ git+https://github.com/Imageomics/sum-buddy.git@v0.2.0-alpha",
+    "sum-buddy",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removes support for 3.7-3.9 ([3.9 is approaching end of life](https://devguide.python.org/versions/), other two have been retired).

Aligns with [sum-buddy update](https://github.com/Imageomics/sum-buddy/pull/20) too.