### PR TITLE
Add Citation and Zenodo metadata

### DIFF
--- a/.github/workflows/validate-zenodo.yaml
+++ b/.github/workflows/validate-zenodo.yaml
@@ -1,0 +1,19 @@
+name: Check zenodo metadata
+
+on: [push]
+
+jobs:
+  check-zenodo-metadata:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install zenodraft@0.14.1
+      - name: Check .zenodo.json file
+        run: |
+          npx zenodraft metadata validate .zenodo.json 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,46 @@
+{
+  "creators": [
+    {
+      "name": "Campolongo, Elizabeth G.",
+      "orcid": "0000-0003-0846-2413"
+    },
+    {
+      "name": "Thompson, Matthew J.",
+      "orcid": "0000-0003-0583-8585"
+    },
+    {
+      "name": "Duan, Zoe",
+      "orcid": "0000-0002-8547-5907"
+    },
+    {
+      "name": "Lapp, Hilmar",
+      "orcid": "0000-0001-9107-0714"
+    }
+  ],
+  "description": "Images from CSV sequential downloader that runs and records checksums on downloaded image folder.",
+  "keywords": [
+    "imageomics",
+    "metadata",
+    "CSV",
+    "images",
+    "download",
+    "sequential download",
+    "verifier",
+    "checksums",
+    "downsized",
+    "url",
+    "downloader",
+    "sum-buddy"
+  ],
+  "license": {
+    "id": "MIT"
+  },
+  "publication_date": "2025-04-03",
+  "title": "Cautious Robot",
+  "version": "1.0.0",
+  "grants": [
+      {
+          "id": "021nxhr62::2118240"
+        }
+    ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,40 @@
+abstract: "Images from CSV sequential downloader that runs and records checksums on downloaded image folder."
+authors:
+- family-names: "Campolongo"
+  given-names: "Elizabeth G."
+  orcid: "https://orcid.org/0000-0003-0846-2413"
+- family-names: "Thompson"
+  given-names: "Matthew J."
+  orcid: "https://orcid.org/0000-0003-0583-8585"
+- family-names: "Zoe"
+  given-names: "Duan"
+  orcid: "https://orcid.org/0000-0002-8547-5907"
+- family-names: "Lapp"
+  given-names: "Hilmar"
+  orcid: "https://orcid.org/0000-0001-9107-0714"
+cff-version: 1.2.0
+date-released: "2024-08-02"
+identifiers:
+  - description: "The GitHub release URL of tag v0.0.2-alpha."
+    type: url
+    value: "https://github.com/Imageomics/cautious-robot/releases/tag/v0.0.2-alpha"
+  - description: "The GitHub URL of the commit tagged with v0.0.2-alpha."
+    type: url
+    value: "https://github.com/Imageomics/cautious-robot/tree/632103d4ddb983ac5b8d58441a5e712b3fdb159f"
+keywords:
+  - imageomics
+  - metadata
+  - CSV
+  - images
+  - download
+  - "sequential download"
+  - verifier
+  - checksums
+  - downsized
+license: MIT
+message: "If you use this software, please cite it using the metadata from this file."
+repository-code: "https://github.com/Imageomics/cautious-robot"
+title: "Cautious Robot"
+version: "0.0.2-alpha"
+# doi: <DOI from Zenodo>
+type: software

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,14 +13,14 @@ authors:
   given-names: "Hilmar"
   orcid: "https://orcid.org/0000-0001-9107-0714"
 cff-version: 1.2.0
-date-released: "2024-08-02"
+date-released: "2025-04-03"
 identifiers:
-  - description: "The GitHub release URL of tag v0.0.2-alpha."
+  - description: "The GitHub release URL of tag v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/cautious-robot/releases/tag/v0.0.2-alpha"
-  - description: "The GitHub URL of the commit tagged with v0.0.2-alpha."
+    value: "https://github.com/Imageomics/cautious-robot/releases/tag/v1.0.0"
+  - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/cautious-robot/tree/632103d4ddb983ac5b8d58441a5e712b3fdb159f"
+    value: "https://github.com/Imageomics/cautious-robot/tree/<commit-hash>" #update on release
 keywords:
   - imageomics
   - metadata
@@ -31,10 +31,12 @@ keywords:
   - verifier
   - checksums
   - downsized
+  - downloader
+  - url
 license: MIT
 message: "If you use this software, please cite it using the metadata from this file."
 repository-code: "https://github.com/Imageomics/cautious-robot"
 title: "Cautious Robot"
-version: "0.0.2-alpha"
+version: "1.0.0"
 # doi: <DOI from Zenodo>
 type: software

--- a/src/cautiousrobot/__about__.py
+++ b/src/cautiousrobot/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.0-alpha"
+__version__ = "1.0.0"


### PR DESCRIPTION
Adds a `CITATION.cff`, the `.zenodo.json` to ensure metadata is added and maintained with Zenodo sync, and a test to ensure the Zenodo metadata file is valid.

Also updates version to 1.0.0.