### PR TITLE
Rename and move AI agent instructions to align with evolving standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for cautious-robot
+# Project Guide for cautious-robot
 
 ## Project Overview
 


### PR DESCRIPTION
As discussed ([internal](https://github.com/Imageomics/data-infra-fwg/issues/24)), we want to standardize agent instructions with the standards now taking form for coding agents.

Additionally, the title in the document is updated to "Project Guide for cautious-robot", as it has more broad applicability. Specifically, we imagine potentially adding a `CONTRIBUTING.md` with more human setup preamble (e.g., environments, code of conduct reference, etc.) that can then point to _this file_ for guidance on the structure of the project