### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/cautiousrobot/__init__.py
+++ b/src/cautiousrobot/__init__.py
@@ -1,3 +1,4 @@
+__version__ = "1.1.0"
 from cautiousrobot.download import download_images
 from cautiousrobot.buddy_check import BuddyCheck
 from cautiousrobot.utils import downsample_and_save_image

--- a/src/cautiousrobot/__init__.py
+++ b/src/cautiousrobot/__init__.py
@@ -1,4 +1,3 @@
-__version__ = "1.1.0"
 from cautiousrobot.download import download_images
 from cautiousrobot.buddy_check import BuddyCheck
 from cautiousrobot.utils import downsample_and_save_image

--- a/src/cautiousrobot/__main__.py
+++ b/src/cautiousrobot/__main__.py
@@ -14,13 +14,21 @@ from sumbuddy import get_checksums
 from cautiousrobot.utils import process_csv, check_existing_images
 from cautiousrobot.buddy_check import BuddyCheck
 from cautiousrobot.download import download_images
+from cautiousrobot import __version__
 
 def parse_args():
     available_algorithms = ', '.join(hashlib.algorithms_available)
 
     parser = argparse.ArgumentParser()
     # Use argument groups for required vs optional (both get short flags too) https://bugs.python.org/issue9694#msg132327
-    # Required arguments
+    # Optional arguments
+    parser.add_argument(
+    "--version",
+    action="version",
+    version=f"%(prog)s {__version__}",
+    help="Show version number and exit",
+)
+     # Required arguments
     req_args = parser.add_argument_group("required arguments")
     req_args.add_argument("-i", "--input-file", required = True, help = "path to CSV file with urls.", nargs = "?")
     req_args.add_argument("-o", "--output-dir", required = True, help = "main directory to download images into.", nargs = "?")

--- a/src/cautiousrobot/__main__.py
+++ b/src/cautiousrobot/__main__.py
@@ -14,7 +14,7 @@ from sumbuddy import get_checksums
 from cautiousrobot.utils import process_csv, check_existing_images
 from cautiousrobot.buddy_check import BuddyCheck
 from cautiousrobot.download import download_images
-from cautiousrobot import __version__
+from cautiousrobot.__about__ import __version__
 
 def parse_args():
     available_algorithms = ', '.join(hashlib.algorithms_available)


### PR DESCRIPTION
Summary
- Add `--version` to the `cautious-robot` CLI so users can check the installed version without relying on `pip list`.

Implementation
- Follow the same pattern used in TaxonoPy: expose a package-level `__version__` and use argparse's built-in `action="version"`.

Testing
- `(cautious-robot-env) [dahlia@cardinal-login01 cautious-robot]$ cautious-robot --version`
`cautious-robot 1.1.0`
